### PR TITLE
[POP-159] Feat: 검색바 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "clsx": "^2.1.1",
         "framer-motion": "^12.23.1",
         "gsap": "^3.13.0",
+        "lodash": "^4.17.21",
         "pretendard": "^1.3.9",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -26,6 +27,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.21.0",
+        "@types/lodash": "^4.17.20",
         "@types/react": "^19.0.10",
         "@types/react-dom": "^19.0.4",
         "@vitejs/plugin-react": "^4.3.4",
@@ -1785,6 +1787,12 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-H3MHACvFUEiujabxhaI/ImO6gUrd8oOurg7LQtS7mbwIXA/cUqWrvBsaeJ23aZEPk1TAYkurjfMbSELfoCXlGA==",
+      "dev": true
     },
     "node_modules/@types/node": {
       "version": "24.0.14",
@@ -3808,6 +3816,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "clsx": "^2.1.1",
     "framer-motion": "^12.23.1",
     "gsap": "^3.13.0",
+    "lodash": "^4.17.21",
     "pretendard": "^1.3.9",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
@@ -29,6 +30,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.21.0",
+    "@types/lodash": "^4.17.20",
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",
     "@vitejs/plugin-react": "^4.3.4",

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -120,7 +120,7 @@ const Header: React.FC<HeaderProps> = ({
       <div
         className={`gmarket transition-all duration-300 ${
           isScrolled
-            ? "mx-auto mt-5 max-w-6xl rounded-[60px] bg-white/80 px-6 backdrop-blur-sm sm:px-8 lg:px-10"
+            ? "mx-auto mt-5 max-w-6xl rounded-[60px] bg-white/80 px-6 sm:px-8 lg:px-10"
             : "max-w-auto mx-auto bg-white/80 px-4 text-lg sm:px-6 lg:px-24"
         }`}
       >

--- a/src/components/common/SearchBar.tsx
+++ b/src/components/common/SearchBar.tsx
@@ -228,7 +228,7 @@ const SearchBar: React.FC<SearchBarProps> = ({
   return (
     <div className="flex justify-center px-4 pt-8">
       <div className="relative w-full max-w-[700px]">
-        <div className="relative flex items-center rounded-full border border-gray-300 bg-white">
+        <div className="relative flex min-w-96 items-center rounded-full border border-gray-300 bg-white">
           <input
             ref={inputRef}
             type="text"

--- a/src/components/common/SearchBar.tsx
+++ b/src/components/common/SearchBar.tsx
@@ -256,7 +256,7 @@ const SearchBar: React.FC<SearchBarProps> = ({
         {showDropdown && suggestions.length > 0 && (
           <div
             ref={dropdownRef}
-            className="absolute left-0 right-0 top-full z-50 max-h-80 overflow-y-auto rounded-b-lg border border-t-0 border-gray-300 bg-white shadow-lg"
+            className="absolute left-6 right-6 top-full z-50 max-h-80 min-w-80 overflow-y-auto rounded-b-lg border border-t-0 border-gray-300 bg-white shadow-lg"
           >
             {suggestions.map((option, index) => (
               <div

--- a/src/components/common/SearchBar.tsx
+++ b/src/components/common/SearchBar.tsx
@@ -228,7 +228,7 @@ const SearchBar: React.FC<SearchBarProps> = ({
   return (
     <div className="flex justify-center px-4 pt-8">
       <div className="relative w-full max-w-[700px]">
-        <div className="relative flex min-w-96 items-center rounded-full border border-gray-300 bg-white">
+        <div className="relative flex min-w-80 items-center rounded-full border border-gray-300 bg-white">
           <input
             ref={inputRef}
             type="text"

--- a/src/components/common/SearchBar.tsx
+++ b/src/components/common/SearchBar.tsx
@@ -1,8 +1,8 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useState, useRef, useEffect } from "react";
 import axios from "axios";
 import { debounce } from "lodash";
 import { SearchOutlined } from "@ant-design/icons";
-import { AutoComplete, Input, Spin } from "antd";
+
 //검색 결과 타입 지정(백엔드 데이터 불러오는 거 보고 수정 예정)
 interface SearchResult {
   id: number;
@@ -47,6 +47,11 @@ const SearchBar: React.FC<SearchBarProps> = ({
   const [suggestions, setSuggestions] = useState<AutoResult[]>([]);
   const [loading, setLoading] = useState<boolean>(false);
   const [searchResult, setSearchResult] = useState<SearchResult[]>([]);
+  const [showDropdown, setShowDropdown] = useState<boolean>(false);
+  const [selectedIndex, setSelectedIndex] = useState<number>(-1);
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
 
   // ElasticSearch(자동완성기능 백엔드 처리)가 적용된 API 호출
   const searchAPI = async (query: string): Promise<SearchResult[]> => {
@@ -72,6 +77,7 @@ const SearchBar: React.FC<SearchBarProps> = ({
       if (!value.trim()) {
         setSuggestions([]);
         setSearchResult([]);
+        setShowDropdown(false);
         return;
       }
       setLoading(true);
@@ -104,6 +110,7 @@ const SearchBar: React.FC<SearchBarProps> = ({
             data: result,
           }));
           setSuggestions(options);
+          setShowDropdown(options.length > 0);
         }
 
         //검색 결과를 부모 컴포넌트에 전달
@@ -116,16 +123,20 @@ const SearchBar: React.FC<SearchBarProps> = ({
   );
 
   //입력값 변경 핸들러
-  const handleInputChange = (value: string): void => {
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
+    const value = e.target.value;
     setSearchValue(value);
+    setSelectedIndex(-1);
     debouncedSearch(value);
   };
 
   //자동완성 선택 핸들러
-  const handleSelect = (value: string, option: AutoResult): void => {
-    setSearchValue(value);
+  const handleSelect = (option: AutoResult): void => {
+    setSearchValue(option.value);
+    setShowDropdown(false);
+    setSelectedIndex(-1);
     if (onSelect) {
-      onSelect(value, option);
+      onSelect(option.value, option);
     }
   };
 
@@ -133,25 +144,128 @@ const SearchBar: React.FC<SearchBarProps> = ({
   const handleSearch = (): void => {
     if (searchValue.trim()) {
       onSearch(searchValue, searchResult);
+      setShowDropdown(false);
+    }
+  };
+
+  // 키보드 이벤트 핸들러
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>): void => {
+    if (!showDropdown || suggestions.length === 0) {
+      if (e.key === "Enter") {
+        handleSearch();
+      }
+      return;
+    }
+
+    switch (e.key) {
+      case "ArrowDown":
+        e.preventDefault();
+        setSelectedIndex((prev) =>
+          prev < suggestions.length - 1 ? prev + 1 : prev,
+        );
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        setSelectedIndex((prev) => (prev > 0 ? prev - 1 : -1));
+        break;
+      case "Enter":
+        e.preventDefault();
+        if (selectedIndex >= 0) {
+          handleSelect(suggestions[selectedIndex]);
+        } else {
+          handleSearch();
+        }
+        break;
+      case "Escape":
+        setShowDropdown(false);
+        setSelectedIndex(-1);
+        break;
+    }
+  };
+
+  // 외부 클릭 감지
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node) &&
+        inputRef.current &&
+        !inputRef.current.contains(event.target as Node)
+      ) {
+        setShowDropdown(false);
+        setSelectedIndex(-1);
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  // 포커스 시 드롭다운 표시
+  const handleFocus = (): void => {
+    if (suggestions.length > 0) {
+      setShowDropdown(true);
     }
   };
 
   return (
-    <AutoComplete
-      options={suggestions}
-      value={searchValue}
-      onChange={handleInputChange}
-      onSelect={handleSelect}
-      className={`${className}`}
-      notFoundContent={loading ? <Spin size="small" /> : null}
-    >
-      <Input.Search
-        placeholder={placeholder}
-        enterButton={<SearchOutlined />}
-        loading={loading}
-        onSearch={handleSearch}
-      />
-    </AutoComplete>
+    <div className="flex justify-center px-4 pt-8">
+      <div className="relative w-full max-w-[700px]">
+        <div className="relative flex items-center rounded-full border border-gray-300 bg-white shadow-sm transition-shadow duration-200 hover:shadow-md">
+          <input
+            ref={inputRef}
+            type="text"
+            value={searchValue}
+            onChange={handleInputChange}
+            onKeyDown={handleKeyDown}
+            onFocus={handleFocus}
+            placeholder={placeholder}
+            className={`h-12 flex-1 border-none bg-transparent px-6 text-base outline-none ${className}`}
+          />
+          <button
+            onClick={handleSearch}
+            disabled={loading}
+            className="mr-3 flex h-16 w-10 items-center justify-center text-black transition-colors duration-200 focus:outline-none disabled:opacity-50"
+          >
+            {loading ? (
+              <div className="h-3 w-3 animate-spin rounded-full border-2 border-white border-t-transparent"></div>
+            ) : (
+              <SearchOutlined className="text-3xl" />
+            )}
+          </button>
+        </div>
+
+        {/* 자동완성 드롭다운 */}
+        {showDropdown && suggestions.length > 0 && (
+          <div
+            ref={dropdownRef}
+            className="absolute left-0 right-0 top-full z-50 max-h-80 overflow-y-auto rounded-b-lg border border-t-0 border-gray-300 bg-white shadow-lg"
+          >
+            {suggestions.map((option, index) => (
+              <div
+                key={index}
+                onClick={() => handleSelect(option)}
+                className={`cursor-pointer border-b border-gray-100 px-4 py-3 last:border-b-0 hover:bg-gray-50 ${
+                  selectedIndex === index ? "bg-blue-50" : ""
+                }`}
+              >
+                {option.label}
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* 로딩 상태 표시 */}
+        {loading && showDropdown && (
+          <div className="absolute left-0 right-0 top-full z-50 rounded-b-lg border border-t-0 border-gray-300 bg-white p-4 text-center shadow-lg">
+            <div className="flex items-center justify-center space-x-2">
+              <div className="h-4 w-4 animate-spin rounded-full border-2 border-gray-400 border-t-transparent"></div>
+              <span className="text-gray-600">검색중...</span>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
   );
 };
 

--- a/src/components/common/SearchBar.tsx
+++ b/src/components/common/SearchBar.tsx
@@ -211,7 +211,7 @@ const SearchBar: React.FC<SearchBarProps> = ({
   return (
     <div className="flex justify-center px-4 pt-8">
       <div className="relative w-full max-w-[700px]">
-        <div className="relative flex items-center rounded-full border border-gray-300 bg-white shadow-sm transition-shadow duration-200 hover:shadow-md">
+        <div className="relative flex items-center rounded-full border border-gray-300 bg-white">
           <input
             ref={inputRef}
             type="text"

--- a/src/components/common/SearchBar.tsx
+++ b/src/components/common/SearchBar.tsx
@@ -228,7 +228,7 @@ const SearchBar: React.FC<SearchBarProps> = ({
             className="mr-3 flex h-16 w-10 items-center justify-center text-black transition-colors duration-200 focus:outline-none disabled:opacity-50"
           >
             {loading ? (
-              <div className="h-3 w-3 animate-spin rounded-full border-2 border-white border-t-transparent"></div>
+              <div className="h-3 w-3 animate-spin rounded-full border-2 border-black border-t-transparent"></div>
             ) : (
               <SearchOutlined className="text-3xl" />
             )}

--- a/src/components/common/SearchBar.tsx
+++ b/src/components/common/SearchBar.tsx
@@ -1,0 +1,158 @@
+import React, { useCallback, useState } from "react";
+import axios from "axios";
+import { debounce } from "lodash";
+import { SearchOutlined } from "@ant-design/icons";
+import { AutoComplete, Input, Spin } from "antd";
+//검색 결과 타입 지정(백엔드 데이터 불러오는 거 보고 수정 예정)
+interface SearchResult {
+  id: number;
+  title: string;
+  content: string;
+  hilights?: {
+    //검색 결과에서 검색어가 포함된 부분을 강조 표시해주는 기능
+    title?: string[];
+    content?: string[];
+  };
+}
+
+//자동완성 옵션 타입(글자 입력시 그에 맞는 검색어 나오는 기능 ex:안녕을 입력하면 아래에 자동완성으로 안녕하세요가 나오는 그런 기능)
+interface AutoResult {
+  value: string;
+  label: React.ReactNode;
+  data?: SearchResult;
+}
+
+interface SearchBarProps {
+  placeholder?: string;
+  onSearch: (value: string, results: SearchResult[]) => void; //검색이 실행될 때 호출되는 콜백 함수. (언제 호출? : 사용자가 검색 버튼 클릭, enter키 눌렀을 때, 실시간 검색에서 결과가 나왔을 때 사용)
+  onSelect?: (value: string, option: AutoResult) => void; //자동완성 목록에서 특정 항목을 선택했을 때 호출되는 콜백 함수 (option: 선택된 항목의 전체 데이터) (언제 호출? : 자동완성 드롭다운에서 항목을 클릭했을 때, 키보드로 항목을 선택하고enter눌렀을 때)
+  apiURL?: string; // 백엔드 API 경로
+  showSuggestions?: boolean;
+  debounceTime?: number;
+  maxSuggestions?: number;
+  className?: string;
+}
+
+const SearchBar: React.FC<SearchBarProps> = ({
+  placeholder = "검색어를 입력 해 주세요.",
+  onSearch,
+  onSelect,
+  apiURL = "",
+  showSuggestions = true,
+  debounceTime = 300,
+  maxSuggestions = 10,
+  className,
+}) => {
+  const [searchValue, setSearchValue] = useState<string>("");
+  const [suggestions, setSuggestions] = useState<AutoResult[]>([]);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [searchResult, setSearchResult] = useState<SearchResult[]>([]);
+
+  // ElasticSearch(자동완성기능 백엔드 처리)가 적용된 API 호출
+  const searchAPI = async (query: string): Promise<SearchResult[]> => {
+    try {
+      const response = await axios.get(apiURL, {
+        params: {
+          q: query,
+          size: maxSuggestions,
+          highlight: true, // 하이라이팅 요청
+        },
+      });
+
+      return response.data; //백엔드 응답 구조에 따라 수정
+    } catch (error) {
+      console.error("검색 api 오류", error);
+      return [];
+    }
+  };
+
+  //디바운스 된 검색 함수
+  const debouncedSearch = useCallback(
+    debounce(async (value: string) => {
+      if (!value.trim()) {
+        setSuggestions([]);
+        setSearchResult([]);
+        return;
+      }
+      setLoading(true);
+      try {
+        const results = await searchAPI(value);
+        setSearchResult(results);
+
+        //자동완성 옵션 생성
+        if (showSuggestions) {
+          const options: AutoResult[] = results.map((result) => ({
+            value: result.title,
+            label: (
+              <div className="py-1">
+                <div
+                  className="mb-[2px] font-bold"
+                  dangerouslySetInnerHTML={{
+                    __html: result.hilights?.title?.[0] || result.title,
+                  }}
+                />
+                <div
+                  className="text-xs text-gray-600"
+                  dangerouslySetInnerHTML={{
+                    __html:
+                      result.hilights?.content?.[0] ||
+                      result.content.substring(0, 100) + "...",
+                  }}
+                />
+              </div>
+            ),
+            data: result,
+          }));
+          setSuggestions(options);
+        }
+
+        //검색 결과를 부모 컴포넌트에 전달
+        onSearch(value, results);
+      } finally {
+        setLoading(false);
+      }
+    }, debounceTime),
+    [apiURL, showSuggestions, maxSuggestions, debounceTime, onSearch],
+  );
+
+  //입력값 변경 핸들러
+  const handleInputChange = (value: string): void => {
+    setSearchValue(value);
+    debouncedSearch(value);
+  };
+
+  //자동완성 선택 핸들러
+  const handleSelect = (value: string, option: AutoResult): void => {
+    setSearchValue(value);
+    if (onSelect) {
+      onSelect(value, option);
+    }
+  };
+
+  //검색 버튼 클릭 핸들러
+  const handleSearch = (): void => {
+    if (searchValue.trim()) {
+      onSearch(searchValue, searchResult);
+    }
+  };
+
+  return (
+    <AutoComplete
+      options={suggestions}
+      value={searchValue}
+      onChange={handleInputChange}
+      onSelect={handleSelect}
+      className={`${className}`}
+      notFoundContent={loading ? <Spin size="small" /> : null}
+    >
+      <Input.Search
+        placeholder={placeholder}
+        enterButton={<SearchOutlined />}
+        loading={loading}
+        onSearch={handleSearch}
+      />
+    </AutoComplete>
+  );
+};
+
+export default SearchBar;

--- a/src/components/common/SearchBar.tsx
+++ b/src/components/common/SearchBar.tsx
@@ -7,12 +7,6 @@ import { SearchOutlined } from "@ant-design/icons";
 interface SearchResult {
   id: number;
   title: string;
-  content: string;
-  hilights?: {
-    //검색 결과에서 검색어가 포함된 부분을 강조 표시해주는 기능
-    title?: string[];
-    content?: string[];
-  };
 }
 
 //자동완성 옵션 타입(글자 입력시 그에 맞는 검색어 나오는 기능 ex:안녕을 입력하면 아래에 자동완성으로 안녕하세요가 나오는 그런 기능)
@@ -97,7 +91,6 @@ const SearchBar: React.FC<SearchBarProps> = ({
         params: {
           q: query,
           size: maxSuggestions,
-          highlight: true, // 하이라이팅 요청
         },
       });
 
@@ -128,20 +121,7 @@ const SearchBar: React.FC<SearchBarProps> = ({
             value: result.title,
             label: (
               <div className="py-1">
-                <div
-                  className="mb-[2px] font-bold"
-                  dangerouslySetInnerHTML={{
-                    __html: result.hilights?.title?.[0] || result.title,
-                  }}
-                />
-                <div
-                  className="text-xs text-gray-600"
-                  dangerouslySetInnerHTML={{
-                    __html:
-                      result.hilights?.content?.[0] ||
-                      result.content.substring(0, 100) + "...",
-                  }}
-                />
+                <div className="mb-[2px] font-bold">{result.title}</div>
               </div>
             ),
             data: result,

--- a/src/components/common/SearchBar.tsx
+++ b/src/components/common/SearchBar.tsx
@@ -53,8 +53,45 @@ const SearchBar: React.FC<SearchBarProps> = ({
   const inputRef = useRef<HTMLInputElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
+  // 더미 데이터 (테스트용)
+  const dummyData: SearchResult[] = [
+    {
+      id: 1,
+      title: "React 시작하기",
+    },
+    {
+      id: 2,
+      title: "JavaScript 기초",
+    },
+    {
+      id: 3,
+      title: "JavaScript 배우기",
+    },
+    {
+      id: 4,
+      title: "Node.js 서버 개발",
+    },
+    {
+      id: 5,
+      title: "CSS 스타일링 가이드",
+    },
+  ];
+
   // ElasticSearch(자동완성기능 백엔드 처리)가 적용된 API 호출
   const searchAPI = async (query: string): Promise<SearchResult[]> => {
+    // 실제 API 호출 대신 더미 데이터로 시뮬레이션
+    if (!apiURL) {
+      // 더미 데이터에서 검색어와 일치하는 항목 필터링
+      const filteredResults = dummyData.filter((item) =>
+        item.title.toLowerCase().includes(query.toLowerCase()),
+      );
+
+      // 실제 API 응답처럼 지연시간 추가
+      await new Promise((resolve) => setTimeout(resolve, 300));
+
+      return filteredResults.slice(0, maxSuggestions);
+    }
+
     try {
       const response = await axios.get(apiURL, {
         params: {

--- a/src/routes/Layout.tsx
+++ b/src/routes/Layout.tsx
@@ -5,7 +5,7 @@ const Layout = () => {
   return (
     <div className="flex min-h-screen flex-col">
       <Header />
-      <main className="flex-grow">
+      <main className="flex-grow pt-[4.5rem]">
         <Outlet />
       </main>
       <Footer />


### PR DESCRIPTION
## 📝 PR 요약
1. 검색바 구현
2. 자잘한 다른 컴포넌트 디자인 수정
## ✅ 체크리스트

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 문서 업데이트
- [ ] 기타

## 📸 스크린샷 (선택)
**검색바 컴포넌트 선언 시 꼭 사진처럼 일단 빈 함수 설정해주셔야 합니다!!**
<img width="275" height="29" alt="image" src="https://github.com/user-attachments/assets/922151f3-0c31-44fb-b3dd-6ff0c5696f07" />

위 함수의 의미는 말 그대로 검색했을 때 props로 넣은 함수를 실행해달라는 의미인데,

검색바를 사용하는 페이지에서 선언 후 '{쿼리문}으로 검색해서 {length}개 찾았음 과 같이 활용 가능하기 때문에 혹시나 해서 남겼습니다 이는 회의를 통해 정하면 될 것 같습니다

**더미 데이터를 활용한 로직은 나중에 api 호출 로직으로 바뀔 예정입니다 커밋 내역 보시면 더미데이터 이전 api 호출 로직 있습니다**
<img width="650" height="467" alt="image" src="https://github.com/user-attachments/assets/ba3d931a-4fa4-4bce-9413-dddbcab7af73" />


**검색바 pc버전**
![검색바pc버전](https://github.com/user-attachments/assets/da5eabf6-75eb-4dc1-b2ff-6b117329567d)

**검색바 반응형**
![검색바반응형](https://github.com/user-attachments/assets/03aed7b7-ad21-4f1d-8fa3-b7e8411320b2)

min값을 주어 최소한의 크기는 유지하도록 해봤습니다

**모바일 버전**
![모바일](https://github.com/user-attachments/assets/e0417be0-832b-458e-b90a-d2c8d0a4b9d3)


## 📚 팀원들에게 요청사항
- 시안에선 width가 700px 이고 radius가 50인데 최대가 어차피 50% 이상이니까 rounded-full 속성을 줘도 괜찮겠다 싶어서 적용했습니다
- border라던가 placeholder의 컬러가 cacaca로 되어있어서  gray-300으로 컬러 넣어놨습니다
- 검색했을 시 자동완성 기능 혹시나 해서 백엔드 조장한테 물어봤는데 마침 그 기능 넣을거라고 하셔서 그에 맞게 작성했습니다
- 일단 페이지 제작 시 필요하시면 머지 후 슬랙이나 디코로 메모 남겨주시면 수정하겠습니다
- 수정사항 있으면 코멘트 남겨주세요 감사합니다

