### PR TITLE
[POP-228] Refactor: 카카오 회원가입 흐름 수정

### DIFF
--- a/src/components/LoginResgisterPage/RegisterForm.tsx
+++ b/src/components/LoginResgisterPage/RegisterForm.tsx
@@ -9,12 +9,8 @@ import {
 import { checkEmail, registerUser } from "@/apis/userApi";
 import { useNavigate } from "react-router-dom";
 
-interface RegisterFormProps {
-  kakaoEmail?: string;
-}
-
-const RegisterForm: React.FC<RegisterFormProps> = ({ kakaoEmail }) => {
-  const [email, setEmail] = useState(kakaoEmail || "");
+const RegisterForm: React.FC = () => {
+  const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [checkPassword, setCheckPassword] = useState("");
 
@@ -23,20 +19,15 @@ const RegisterForm: React.FC<RegisterFormProps> = ({ kakaoEmail }) => {
   const [checkPasswordError, setCheckPasswordError] = useState("");
 
   const [checkEmailValue, setCheckEmailValue] = useState(false); // 이메일 중복 체크
-  const isKakaoEmail = Boolean(kakaoEmail); //카카오 이메일 여부 확인
 
   const navigate = useNavigate();
 
   useEffect(() => {
     const resetCheckEmailValue = () => {
       setCheckEmailValue(false);
-      if (kakaoEmail) {
-        setCheckEmailValue(true);
-        setEmailError("");
-      }
     };
     resetCheckEmailValue();
-  }, [kakaoEmail]);
+  }, []);
 
   // 로그인 버튼 핸들러
   const handleSubmit = async (e: React.FormEvent) => {
@@ -102,10 +93,6 @@ const RegisterForm: React.FC<RegisterFormProps> = ({ kakaoEmail }) => {
   const handleCheckEmail = async (e: React.FormEvent) => {
     e.preventDefault();
 
-    if (isKakaoEmail) {
-      return; //카카오 이메일인 경우 중복확인 버튼 클릭 방지
-    }
-
     if (!email) {
       alert("이메일을 입력해주세요.");
       return;
@@ -135,13 +122,12 @@ const RegisterForm: React.FC<RegisterFormProps> = ({ kakaoEmail }) => {
         <motion.div className="w-full max-w-[500px]" variants={itemVariants}>
           <div className="flex justify-between">
             <label className="mb-2 ml-4 block text-xs text-black md:text-base">
-              이메일 {isKakaoEmail && <span>&nbsp;(카카오)</span>}
+              이메일
             </label>
             <button
               type="button"
-              className={`mb-2 mr-4 ${isKakaoEmail ? "cursor-not-allowed" : ""}`}
+              className={`mb-2 mr-4`}
               onClick={handleCheckEmail}
-              disabled={isKakaoEmail}
             >
               중복 확인
             </button>
@@ -152,13 +138,11 @@ const RegisterForm: React.FC<RegisterFormProps> = ({ kakaoEmail }) => {
             placeholder="Email Address"
             className={`white w-full rounded-[40px] border-0 px-3 py-3 font-medium text-gray-600 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-[#ffd751] md:px-4 md:py-4 ${
               emailError ? "border-2 border-red-400" : ""
-            } ${isKakaoEmail ? "cursor-not-allowed" : ""}`}
+            } `}
             onChange={(e) => {
-              if (!isKakaoEmail) {
-                setEmail(e.target.value);
-                setCheckEmailValue(false);
-                if (e.target.value) setEmailError("");
-              }
+              setEmail(e.target.value);
+              setCheckEmailValue(false);
+              if (e.target.value) setEmailError("");
             }}
           />
           {emailError && (

--- a/src/pages/KakaoCallback.tsx
+++ b/src/pages/KakaoCallback.tsx
@@ -70,12 +70,7 @@ const KakaoCallback: React.FC = () => {
 
         if (result.message == "SIGNUP") {
           addDebugLog("SIGNUP 플로우 진입");
-          navigate("/register", {
-            state: {
-              kakaoEmail: result.data.email,
-            },
-          });
-          addDebugLog("회원가입 페이지로 이동 완료");
+          navigate("/test");
           console.log("signup됐음");
           return;
         }

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -106,21 +106,13 @@ const LoginPage: React.FC = () => {
                   </Link>
                 </p>
               </motion.div>
-              <div className="mt-4 flex w-full justify-center md:mt-6 md:pt-8">
+              <div className="mt-4 flex w-full justify-center md:mt-6 md:pt-8 lg:mt-0 lg:pt-6">
                 <motion.div
                   className="flex h-16 w-full max-w-[500px] gap-2 md:gap-3 xl:mt-5"
                   variants={socialContainerVariants}
                   initial="hidden"
                   animate="visible"
                 >
-                  <motion.button
-                    className="flex flex-1 items-center justify-center rounded-xl bg-[#03c75a] px-3 py-2.5 text-xs font-medium text-white transition-colors md:px-4 md:py-3 md:text-sm lg:text-base xl:text-xl"
-                    variants={socialButtonVariants}
-                    whileTap="tap"
-                  >
-                    <span className="mr-2 font-bold">N</span>
-                    네이버 로그인
-                  </motion.button>
                   <motion.button
                     className="flex flex-1 items-center justify-center rounded-xl bg-[#FEE500] px-3 py-2.5 text-xs font-medium text-black transition-colors md:px-4 md:py-3 md:text-sm lg:text-base xl:text-xl"
                     variants={socialButtonVariants}
@@ -204,10 +196,6 @@ const LoginPage: React.FC = () => {
                 initial="hidden"
                 animate="visible"
               >
-                <button className="flex flex-1 items-center justify-center rounded-xl bg-green-500 px-3 py-2.5 text-xs font-medium text-white transition-colors">
-                  <span className="mr-2 font-bold">N</span>
-                  네이버 로그인
-                </button>
                 <button
                   className="flex flex-1 items-center justify-center rounded-xl bg-[#FEE500] px-3 py-2.5 text-xs font-medium text-black transition-colors"
                   onClick={handleKakaoLogin}

--- a/src/pages/RegisterPage.tsx
+++ b/src/pages/RegisterPage.tsx
@@ -4,7 +4,7 @@ import spotlightWithLogoImg from "@/assets/spotlight-with-logo.svg";
 import loginPopcoImg from "@/assets/login-popco.svg";
 import RegisterForm from "@/components/LoginResgisterPage/RegisterForm";
 import { motion } from "framer-motion";
-import { Link, useLocation } from "react-router-dom";
+import { Link } from "react-router-dom";
 import {
   pageVariants,
   characterVariants,
@@ -13,7 +13,6 @@ import {
 } from "@/components/LoginResgisterPage/Animation";
 
 const RegisterPage: React.FC = () => {
-  const location = useLocation();
   return (
     <motion.main
       className="pretendard relative h-full bg-[#0F1525]"

--- a/src/pages/RegisterPage.tsx
+++ b/src/pages/RegisterPage.tsx
@@ -14,7 +14,6 @@ import {
 
 const RegisterPage: React.FC = () => {
   const location = useLocation();
-  const kakaoEmail = location.state?.kakaoEmail;
   return (
     <motion.main
       className="pretendard relative h-full bg-[#0F1525]"
@@ -80,7 +79,7 @@ const RegisterPage: React.FC = () => {
                 </p>
               </motion.div>
 
-              <RegisterForm kakaoEmail={kakaoEmail} />
+              <RegisterForm />
 
               <motion.div
                 className="mt-4 flex justify-center lg:mt-6"


### PR DESCRIPTION
## 📝 PR 요약
1. 카카오로 최초 회원가입 시 회원가입 폼으로 넘어가는 흐름을 삭제했습니다

2. 네이버 로그인 미지원으로 인한 네이버 로그인 버튼 삭제했습니다
## ✅ 체크리스트

- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 문서 업데이트
- [x] 기타

## 📸 스크린샷 (선택)
<img width="1876" height="902" alt="image" src="https://github.com/user-attachments/assets/db0e3e80-0df8-49b3-972d-bee4f6fe6860" />

## 📌 CodeRabbit 리뷰 가이드라인

> 아래 기준에 따라 리뷰해주세요. (작성자 및 리뷰어 모두 참고)

- 컴포넌트 이름, 함수, 변수는 모두 camelCase를 사용합니다.
- Tailwind CSS를 사용하고, inline style은 지양합니다.
- 재사용 가능한 UI는 components 디렉토리로 분리합니다.
- 훅은 항상 컴포넌트 최상단에서 호출합니다 (React Hooks 규칙).
- props와 state는 명확한 타입(TypeScript)을 지정합니다.
- any 타입 사용은 피하고, 명확한 타입 추론을 우선합니다.
- 조건부 렌더링에는 &&, ? : 등의 간결한 구문을 사용합니다.
- 복잡한 로직에는 주석 또는 분리된 함수로 명확하게 표현합니다.

## 📚 팀원들에게 요청사항
